### PR TITLE
#9 Versions missing for python libraries

### DIFF
--- a/load_embedding_model.ipynb
+++ b/load_embedding_model.ipynb
@@ -60,7 +60,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "Elastic uses the [eland python library](https://github.com/elastic/eland) to download models from Hugging Face hub and load them into elasticsearch"
+        "Elastic uses the [eland python library](https://github.com/elastic/eland) to download modesl from Hugging Face hub and load them into elasticsearch"
       ],
       "metadata": {
         "id": "MJAb_8zlPFhQ"

--- a/load_embedding_model.ipynb
+++ b/load_embedding_model.ipynb
@@ -60,7 +60,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "Elastic uses the [eland python library](https://github.com/elastic/eland) to download modesl from Hugging Face hub and load them into elasticsearch"
+        "Elastic uses the [eland python library](https://github.com/elastic/eland) to download models from Hugging Face hub and load them into elasticsearch"
       ],
       "metadata": {
         "id": "MJAb_8zlPFhQ"

--- a/load_embedding_model.ipynb
+++ b/load_embedding_model.ipynb
@@ -74,7 +74,7 @@
       },
       "outputs": [],
       "source": [
-        "pip -q install eland elasticsearch sentence_transformers transformers torch==1.11"
+        "pip -q install eland==8.7.0 elasticsearch sentence_transformers transformers torch==1.11"
       ]
     },
     {


### PR DESCRIPTION
The latest version available for eland library requires a different torch library version. Version for eland set to the latest version available by the time the article was published.